### PR TITLE
Migrate to Envoy v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,9 @@ The `backend` is a simple go http service. It prints the headers it gets to make
 * You'll also need a local copy of lyft's ratelimit. Submodules were causing some challenges, so it's easiest to `git clone git@github.com:lyft/ratelimit.git`
 
 
-I had to make some manual tweaks to the `ratelimit` codebase to get it to build -- which may be operator error:
+I had to make a tweak to the `ratelimit` codebase to get it to build -- which may be operator error:
 
 * `mkdir ratelimit/vendor` (the `Dockerfile` expects it to exist already)
-* add a `COPY proto proto` to the `Dockerfile` with the rest of the `COPY` statements
 
 Finally run:
 

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -13,7 +13,7 @@ static_resources:
       - filters:
         - name: envoy.http_connection_manager
           typed_config:
-            "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
             stat_prefix: ingress_http
             codec_type: AUTO
             route_config:
@@ -39,22 +39,28 @@ static_resources:
                           - {request_headers: {header_name: "x-ext-auth-ratelimit", descriptor_key: "ratelimitkey"}}
                           - {request_headers: {header_name: ":path", descriptor_key: "path"}}
             http_filters:
-            - name: envoy.ext_authz
-              config:
+            - name: extensions.filters.http.ext_authz.v3.ExtAuthz
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                transport_api_version: V3
                 grpc_service:
                   envoy_grpc:
                     cluster_name: extauth
-            - name: envoy.rate_limit
-              config:
+                  timeout: 0.5s
+            - name: envoy.filters.http.ratelimit
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
                 domain: backend
                 stage: 0
                 failure_mode_deny: false
                 rate_limit_service:
+                  transport_api_version: V3
                   grpc_service:
                     envoy_grpc:
                       cluster_name: rate_limit_cluster
                     timeout: 0.25s
-            - name: envoy.router
+            - name: envoy.filters.http.router
+              typed_config: {}
   clusters:
   - name: backend
     connect_timeout: 0.25s
@@ -89,8 +95,12 @@ static_resources:
     connect_timeout: 0.25s
     lb_policy: round_robin
     http2_protocol_options: {}
-    hosts:
-    - socket_address:
-        address: ratelimit
-        port_value: 8081
-
+    load_assignment:
+      cluster_name: ratelimit_gloo-system
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: ratelimit
+                    port_value: 8081

--- a/extauth/main.go
+++ b/extauth/main.go
@@ -8,10 +8,11 @@ import (
 	"net"
 	"strings"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
-	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-	"github.com/gogo/googleapis/google/rpc"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc"
 )
 
@@ -25,6 +26,7 @@ func (a *AuthorizationServer) Check(ctx context.Context, req *auth.CheckRequest)
 	if ok {
 		splitToken = strings.Split(authHeader, "Bearer ")
 	}
+	log.Printf("checking bearer token")
 	if len(splitToken) == 2 {
 		token := splitToken[1]
 		sha := sha256.New()
@@ -35,9 +37,10 @@ func (a *AuthorizationServer) Check(ctx context.Context, req *auth.CheckRequest)
 		// Normally this is where you'd go check with the system that knows if it's a valid token.
 
 		if len(token) == 3 {
+			log.Printf("bearer token is good")
 			return &auth.CheckResponse{
-				Status: &rpc.Status{
-					Code: int32(rpc.OK),
+				Status: &status.Status{
+					Code: int32(code.Code_OK),
 				},
 				HttpResponse: &auth.CheckResponse_OkResponse{
 					OkResponse: &auth.OkHttpResponse{
@@ -54,9 +57,10 @@ func (a *AuthorizationServer) Check(ctx context.Context, req *auth.CheckRequest)
 			}, nil
 		}
 	}
+	log.Printf("bearer token is not good")
 	return &auth.CheckResponse{
-		Status: &rpc.Status{
-			Code: int32(rpc.UNAUTHENTICATED),
+		Status: &status.Status{
+			Code: int32(code.Code_UNAUTHENTICATED),
 		},
 		HttpResponse: &auth.CheckResponse_DeniedResponse{
 			DeniedResponse: &auth.DeniedHttpResponse{


### PR DESCRIPTION
I found your [Envoy + Custom Auth + Ratelimiter Example](https://serialized.net/2019/05/envoy-ratelimits/) blog post useful as I started to look at using Envoy in a similar setup.  Since that blog post was written, it looks like older Envoy config versions have been deprecated, and the config in this repo no longer loads.  This PR shows the changes I made to get your example setup working again, now with a V3-compatible config.

This PR is not necessarily intended for merging — feel free to merge it if you like, or copy the changes over, or close the PR without doing anything.  I just thought it could be useful to document what's needed to get the example working again.